### PR TITLE
refactor: put command/mediator logic to Fabron.Mando

### DIFF
--- a/src/Core.Test/Grains/TestCommand.cs
+++ b/src/Core.Test/Grains/TestCommand.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
-using Fabron.Contracts;
 using Fabron.Grains;
+using Fabron.Mando;
 
 namespace Fabron.Test.Grains
 {

--- a/src/Core.Test/Grains/TransientJob/TransientGrainTests.cs
+++ b/src/Core.Test/Grains/TransientJob/TransientGrainTests.cs
@@ -10,8 +10,8 @@ using Orleans.Runtime;
 using Orleans.TestKit;
 using Orleans.TestKit.Reminders;
 using Fabron.Grains.TransientJob;
-using Fabron.Services;
 using Xunit;
+using Fabron.Mando;
 
 namespace Fabron.Test.Grains.TransientJob
 {

--- a/src/Core/Contracts/JobInfo.cs
+++ b/src/Core/Contracts/JobInfo.cs
@@ -1,3 +1,5 @@
+using Fabron.Mando;
+
 namespace Fabron.Contracts
 {
     public record JobCommandInfo<TCommand>(

--- a/src/Core/Contracts/JobMappings.cs
+++ b/src/Core/Contracts/JobMappings.cs
@@ -6,7 +6,7 @@ using Fabron.Grains.BatchJob;
 using Fabron.Grains.CronJob;
 //using Fabron.Grains.CronJob;
 using Fabron.Grains.TransientJob;
-using Fabron.Services;
+using Fabron.Mando;
 
 namespace Fabron.Contracts
 {

--- a/src/Core/Contracts/TransientJob.cs
+++ b/src/Core/Contracts/TransientJob.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Fabron.Mando;
 
 namespace Fabron.Contracts
 {

--- a/src/Core/Fabron.Core.csproj
+++ b/src/Core/Fabron.Core.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Mando\Fabron.Mando.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Core/Grains/BatchJob/BatchJobGrain.cs
+++ b/src/Core/Grains/BatchJob/BatchJobGrain.cs
@@ -8,7 +8,7 @@ using Orleans;
 using Orleans.Concurrency;
 using Orleans.Runtime;
 using Fabron.Grains.TransientJob;
-using Fabron.Services;
+using Fabron.Mando;
 
 namespace Fabron.Grains.BatchJob
 {

--- a/src/Core/Grains/CronJob/CronJobGrain.cs
+++ b/src/Core/Grains/CronJob/CronJobGrain.cs
@@ -8,7 +8,7 @@ using Orleans;
 using Orleans.Concurrency;
 using Orleans.Runtime;
 using Fabron.Grains.TransientJob;
-using Fabron.Services;
+using Fabron.Mando;
 
 namespace Fabron.Grains.CronJob
 {

--- a/src/Core/Grains/TransientJob/TransientJobGrain.cs
+++ b/src/Core/Grains/TransientJob/TransientJobGrain.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Concurrency;
 using Orleans.Runtime;
-using Fabron.Services;
+using Fabron.Mando;
 
 namespace Fabron.Grains.TransientJob
 {

--- a/src/Core/HostBuilderExtensions.cs
+++ b/src/Core/HostBuilderExtensions.cs
@@ -4,7 +4,7 @@ using Orleans;
 using Orleans.Hosting;
 using Fabron;
 using Fabron.Grains.TransientJob;
-using Fabron.Services;
+using Fabron.Mando;
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Core/IJobManager.cs
+++ b/src/Core/IJobManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Fabron.Contracts;
+using Fabron.Mando;
 
 namespace Fabron
 {

--- a/src/Core/JobManager.Batch.cs
+++ b/src/Core/JobManager.Batch.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Fabron.Contracts;
 using Fabron.Grains.BatchJob;
+using Fabron.Mando;
 
 namespace Fabron
 {

--- a/src/Core/JobManager.Cron.cs
+++ b/src/Core/JobManager.Cron.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Fabron.Contracts;
 using Fabron.Grains.CronJob;
 using Fabron.Grains.TransientJob;
+using Fabron.Mando;
 
 namespace Fabron
 {

--- a/src/Core/JobManager.Transient.cs
+++ b/src/Core/JobManager.Transient.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Fabron.Contracts;
 using Fabron.Grains.TransientJob;
+using Fabron.Mando;
 
 namespace Fabron
 {

--- a/src/Core/JobManager.cs
+++ b/src/Core/JobManager.cs
@@ -4,7 +4,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans;
-using Fabron.Services;
+using Fabron.Mando;
 
 namespace Fabron
 {

--- a/src/Mando/CommandRegistry.cs
+++ b/src/Mando/CommandRegistry.cs
@@ -4,9 +4,8 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Fabron.Contracts;
 
-namespace Fabron.Services
+namespace Fabron.Mando
 {
     public delegate Task<string?> HandleDelegate(IServiceProvider serviceProvider, string commandData, CancellationToken token);
 

--- a/src/Mando/Fabron.Mando.csproj
+++ b/src/Mando/Fabron.Mando.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MEXVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Mando/ICommand.cs
+++ b/src/Mando/ICommand.cs
@@ -1,6 +1,4 @@
-using System.Text.Json;
-
-namespace Fabron.Contracts
+namespace Fabron.Mando
 {
     public interface ICommand
     { }

--- a/src/Mando/ICommandHandler.cs
+++ b/src/Mando/ICommandHandler.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Fabron.Contracts
+namespace Fabron.Mando
 {
     public interface ICommandHandler<in TCommand, TResult> where TCommand : ICommand<TResult>
     {

--- a/src/Mando/Mediator.cs
+++ b/src/Mando/Mediator.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
-namespace Fabron.Services
+namespace Fabron.Mando
 {
     public interface IMediator
     {

--- a/src/Mando/MediatorServiceCollectionExtensions.cs
+++ b/src/Mando/MediatorServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using System.Reflection;
-using Fabron.Contracts;
-using Fabron.Services;
+using Fabron.Mando;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Server/Entities/RequestWebAPI.cs
+++ b/src/Server/Entities/RequestWebAPI.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Fabron.Contracts;
+using Fabron.Mando;
 
 namespace Fabron.Server.Entities
 {


### PR DESCRIPTION
Fabron.Mando can be a command invocation library and to be published independently