### PR TITLE
Enable UnsafeBinaryFormatterSerialization

### DIFF
--- a/src/FabronService/FabronService.csproj
+++ b/src/FabronService/FabronService.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <UserSecretsId>6c552e26-7778-457d-a066-8b42b62b8e53</UserSecretsId>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
to fix the serialization error on exceptoins, see https://github.com/dotnet/orleans/issues/6805#issuecomment-717778302